### PR TITLE
Potential fix for code scanning alert no. 5: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^9.0.0",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "lusca": "^1.7.0"
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import { Server } from 'socket.io';
 import { apiLimiter } from './utils/apiLimiter.utils.js';
 import passport from 'passport';
 import session from 'express-session';
+import lusca from 'lusca';
 import swaggerUi from 'swagger-ui-express';
 import authRouter from './routes/auth.routes.js';
 import userRoutes from './routes/user.routes.js';
@@ -70,6 +71,7 @@ app.use(
     },
   }),
 );
+app.use(lusca.csrf());
 
 app.use(passport.initialize());
 app.use(passport.session());


### PR DESCRIPTION
Potential fix for [https://github.com/TaskTrial/server/security/code-scanning/5](https://github.com/TaskTrial/server/security/code-scanning/5)

To fix the issue, we will add CSRF protection middleware to the application. The `lusca` library is a well-known middleware for CSRF protection in Express applications. We will:
1. Install the `lusca` package.
2. Import the `lusca` library and configure its `csrf` middleware.
3. Add the `csrf` middleware to the Express app after the session middleware is initialized.
4. Ensure that the CSRF token is included in responses where necessary (e.g., in forms or headers) to allow the client to send it back with subsequent requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
